### PR TITLE
Save and load journal data.

### DIFF
--- a/MyJournal/Client/FileIOClient.swift
+++ b/MyJournal/Client/FileIOClient.swift
@@ -1,0 +1,37 @@
+//
+//  FileIOClient.swift
+//  MyJournal
+//
+//  Created by Reid on 2023/11/28.
+//
+
+import Foundation
+import Dependencies
+
+struct FileIOClient: Sendable {
+  var save: @Sendable (Data, URL) async throws -> Void
+  var load: @Sendable (URL) throws -> Data
+}
+
+extension FileIOClient: DependencyKey {
+  static let liveValue = Self(
+    save: { data, url in
+      try data.write(to: url)
+    },
+    load: { url in
+      try Data(contentsOf: url)
+    }
+  )
+  
+  static let testValue = Self(
+    save: unimplemented("FileIOClient.save"),
+    load: unimplemented("FileIOClient.load")
+  )
+}
+
+extension DependencyValues {
+  var fileIOClient: FileIOClient {
+    get { self[FileIOClient.self] }
+    set { self[FileIOClient.self] = newValue }
+  }
+}

--- a/MyJournal/Logic/JournalHome.swift
+++ b/MyJournal/Logic/JournalHome.swift
@@ -13,6 +13,21 @@ struct JournalHome {
   struct State: Equatable {
     @PresentationState var destination: Destination.State?
     var journals: IdentifiedArrayOf<Journal> = []
+    
+    init(destination: Destination.State? = nil) {
+      self.destination = destination
+      
+      do {
+        @Dependency(\.fileIOClient.load) var loadJournals
+        self.journals = try JSONDecoder().decode(IdentifiedArray.self, from: loadJournals(.journalDataUrl))
+      }
+      catch is DecodingError {
+        NSLog("Failed to load data (decoding data failed)")
+      }
+      catch {
+        NSLog("Failed to load data (Unknown)")
+      }
+    }
   }
   
   enum Action {
@@ -41,7 +56,7 @@ struct JournalHome {
       case .addNewJournal:
         guard case let .sheetToAdd(meta) = state.destination else {
           return .none
-        }        
+        }
         
         state.journals.append(meta.journal)
         state.destination = nil

--- a/MyJournal/Model/URL+Extension.swift
+++ b/MyJournal/Model/URL+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  URL+Extension.swift
+//  MyJournal
+//
+//  Created by Reid on 2023/11/28.
+//
+
+import Foundation
+
+
+
+extension URL {
+  static let journalDataUrl = Self.documentsDirectory.appending(component: "my-journals.json")
+}

--- a/MyJournal/View/JournalHomeView.swift
+++ b/MyJournal/View/JournalHomeView.swift
@@ -96,7 +96,14 @@ struct CreateButton: View {
 
 #Preview {
   JournalHomeView(
-    store: Store(initialState: JournalHome.State(journals: [.mock])) {
+    store: Store(initialState: JournalHome.State()) {
       JournalHome()
-    })
+    } withDependencies: {
+      $0.fileIOClient.load = { _ in
+        try JSONEncoder().encode([
+          Journal.mock
+        ])
+      }
+    }
+  )
 }


### PR DESCRIPTION
## Summary
Saving data to a file and loading it when the `Home` view is loaded.

## Changes
* A task to save journals was added.
* A initializer fo `JournalHome.State()` was changed to load a file.

## Issues
None